### PR TITLE
:sparkles: add plot argument

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: orthomap
 Title: An R package to plot World in orthographic projection without aberrations
 Version: 1.0.0
-Date: 2017-12-06
+Date: 2020-04-03
 Authors@R: person("Nicolas", "Casajus", email = "nicolas.casajus@gmail.com", role = c("aut", "cre"))
 Description:
     The package \textbf{orthomap} contains only one function: \code{orthomap()}. It corrects a bug (some polygons are not correctly projected) in the function \code{maps:map()} when it is used in orthographic projection. The function \code{orthomap()} also returns projected polygons in the \code{sp:SpatialPolygons} format.
@@ -14,5 +14,5 @@ LazyData: true
 Imports: maps, mapproj, rgdal, rgeos, sp, stats
 Suggests: knitr, rmarkdown
 VignetteBuilder: knitr
-RoxygenNote: 6.0.1
+RoxygenNote: 7.1.0
 NeedsCompilation: no

--- a/R/orthomap.R
+++ b/R/orthomap.R
@@ -8,6 +8,7 @@
 #'
 #' @param query The name of a country to center the map on.
 #' @param centre Latitude and longitude of the map center. Ignored if query is not \code{NULL}.
+#' @param plot If TRUE, the map is plotted.
 #' @param border.color Color of polygons border.
 #' @param border.type Type of polygons border line (see argument \code{lty}).
 #' @param border.size Size of polygons border line (see argument \code{lwd}).
@@ -32,6 +33,8 @@
 #' @examples
 #' # Default settings
 #' world <- orthomap()
+#' # Create the map but don't plot it
+#' world <- orthomap(plot = FALSE)
 #'
 #' class(world)
 #' length(world)
@@ -66,6 +69,7 @@
 orthomap <- function(
   query        = NULL,
   centre       = c(0, 0),
+  plot         = TRUE,
   border.color = NA,
   border.type  = 1,
   border.size  = 0.25,
@@ -133,7 +137,7 @@ orthomap <- function(
 
   ### Find polygons delimitation
 
-  naloc <- (1L:nrow(coord))[!complete.cases(coord)]
+  naloc <- seq_len(nrow(coord))[!complete.cases(coord)]
   naloc <- c(0, naloc, nrow(coord) + 1)
 
 
@@ -242,51 +246,52 @@ orthomap <- function(
 
 
   ### Plot world map in ortho
+  if (plot) {
+    graphics::par(...)
 
-  graphics::par(...)
-
-  ooo <- options()$warn
-  options(warn = -1)
-  maps::map("world", proj = "orthographic", orient = c(centre, 0), col = NA)
-  options(warn = ooo)
-
-  sp::plot(
-    globe,
-    col    = globe.col,
-    border = grid.color,
-    lty    = grid.type,
-    lwd    = grid.size,
-    add    = TRUE
-  )
-
-  sp::plot(
-    world,
-    col    = fill,
-    border = border.color,
-    lty    = border.type,
-    lwd    = border.size,
-    add    = TRUE
-  )
-
-  if (grid) {
+    ooo <- options()$warn
+    options(warn = -1)
+    maps::map("world", proj = "orthographic", orient = c(centre, 0), col = NA)
+    options(warn = ooo)
 
     sp::plot(
       globe,
-      col    = "transparent",
+      col    = globe.col,
       border = grid.color,
       lty    = grid.type,
       lwd    = grid.size,
       add    = TRUE
     )
 
-    mapproj::map.grid(
-      nx     = nx,
-      ny     = ny,
-      labels = FALSE,
-      col    = grid.color,
-      lty    = grid.type,
-      lwd    = grid.size
+    sp::plot(
+      world,
+      col    = fill,
+      border = border.color,
+      lty    = border.type,
+      lwd    = border.size,
+      add    = TRUE
     )
+
+    if (grid) {
+
+      sp::plot(
+        globe,
+        col    = "transparent",
+        border = grid.color,
+        lty    = grid.type,
+        lwd    = grid.size,
+        add    = TRUE
+      )
+
+      mapproj::map.grid(
+        nx     = nx,
+        ny     = ny,
+        labels = FALSE,
+        col    = grid.color,
+        lty    = grid.type,
+        lwd    = grid.size
+      )
+    }
   }
 
   invisible(world)

--- a/README.md
+++ b/README.md
@@ -16,18 +16,15 @@ Installation
 To install the package **orthomap** from GitHub, first install the package [**devtools**](http://cran.r-project.org/web/packages/devtools/index.html) from the CRAN.
 
 ```r
-### Install the < devtools > package
-install.packages("devtools", dependencies = TRUE)
-
-### Load the < devtools > package
-library(devtools)
+### Install the < emotes > package
+install.packages("remotes")
 ```
 
 Then install the **orthomap** package:
 
 ```r
 ### Install the < orthomap > package from GitHub
-devtools::install_github("ahasverus/orthomap")
+remotes::install_github("ahasverus/orthomap")
 
 ### Load the < orthomap > package
 library(orthomap)

--- a/man/orthomap.Rd
+++ b/man/orthomap.Rd
@@ -4,15 +4,30 @@
 \alias{orthomap}
 \title{Create a World map in orthographic projection}
 \usage{
-orthomap(query = NULL, centre = c(0, 0), border.color = NA,
-  border.type = 1, border.size = 0.25, fill = "#909090",
-  globe = "transparent", grid = TRUE, nx = 10, ny = 10,
-  grid.color = "#969696", grid.type = 1, grid.size = 0.25, ...)
+orthomap(
+  query = NULL,
+  centre = c(0, 0),
+  plot = TRUE,
+  border.color = NA,
+  border.type = 1,
+  border.size = 0.25,
+  fill = "#909090",
+  globe = "transparent",
+  grid = TRUE,
+  nx = 10,
+  ny = 10,
+  grid.color = "#969696",
+  grid.type = 1,
+  grid.size = 0.25,
+  ...
+)
 }
 \arguments{
 \item{query}{The name of a country to center the map on.}
 
 \item{centre}{Latitude and longitude of the map center. Ignored if query is not \code{NULL}.}
+
+\item{plot}{If TRUE, the map is plotted.}
 
 \item{border.color}{Color of polygons border.}
 
@@ -50,6 +65,8 @@ function \code{orthomap()} also returns projected polygons in the
 \examples{
 # Default settings
 world <- orthomap()
+# Create the map but don't plot it
+world <- orthomap(plot = FALSE)
 
 class(world)
 length(world)


### PR DESCRIPTION
I am using this function but as I want to include in a multi-panels figure, I have to plot it  twice, which is slightly annoying! So I added `plot` as an option! 

I did some (very) minor changes.